### PR TITLE
Adding nine nodes flag

### DIFF
--- a/cfy_cluster_manager/cfy_cluster_config_files/cfy_nine_nodes_cluster_config.yaml
+++ b/cfy_cluster_manager/cfy_cluster_config_files/cfy_nine_nodes_cluster_config.yaml
@@ -1,8 +1,8 @@
-# Your private key local path to connect to all hosts
-key_file_path: ''
+# Your private SSH key local path used to connect to all VMs
+ssh_key_path: ''
 
-# The hosts' username, e.g. centos
-machine_username: ''
+# The VMs' SSH username, e.g. centos
+ssh_user: ''
 
 # Local path to a valid Cloudify license
 cloudify_license_path: ''
@@ -10,11 +10,13 @@ cloudify_license_path: ''
 # Manager RPM to install on the cluster instances
 manager_rpm_download_link: 'http://cloudify-release-eu.s3.amazonaws.com/cloudify/5.1.0/.dev1-release/cloudify-manager-install-5.1.0-.dev1.el7.x86_64.rpm'
 
-# If specified, all the VMs certificates will need to be specified as well
+# If specified, all the VMs' certificates will need to be specified as well
 ca_cert_path: ''
 
 # If using a load-balancer, please provide its IP.
-# This IP will be written the the config.yaml files.
+# This IP will be written to the manager config.yaml files under
+# networks[load_balancer].
+# Remark: The load balancer is not installed during the cluster installation.
 load_balancer_ip: ''
 
 
@@ -83,7 +85,7 @@ existing_vms:
       key_path: ''  # Need to be supplied if ca_cert_path was supplied
 
 
-# If the credentials are not specified, random ones will be used and written to {{ credentials_file_path }}
+# If the credentials are not specified, random self-generated ones will be used and written to {{ credentials_file_path }}
 credentials:
   manager:
     admin_username: 'admin'

--- a/cfy_cluster_manager/cfy_cluster_config_files/cfy_nine_nodes_external_db_cluster_config.yaml
+++ b/cfy_cluster_manager/cfy_cluster_config_files/cfy_nine_nodes_external_db_cluster_config.yaml
@@ -1,8 +1,8 @@
-# Your private key local path to connect to all hosts
-key_file_path: ''
+# Your private SSH key local path used to connect to all VMs
+ssh_key_path: ''
 
-# The hosts' username, e.g. centos
-machine_username: ''
+# The VMs' SSH username, e.g. centos
+ssh_user: ''''
 
 # Local path to a valid Cloudify license
 cloudify_license_path: ''
@@ -14,7 +14,9 @@ manager_rpm_download_link: 'http://cloudify-release-eu.s3.amazonaws.com/cloudify
 ca_cert_path: ''
 
 # If using a load-balancer, please provide its IP.
-# This IP will be written the the config.yaml files.
+# This IP will be written to the manager config.yaml files under
+# networks[load_balancer].
+# Remark: The load balancer is not installed during the cluster installation.
 load_balancer_ip: ''
 
 
@@ -86,7 +88,7 @@ external_db_configuration:
   cloudify_password: ''
 
 
-# If the credentials are not specified, random ones will be used and written to {{ credentials_file_path }}
+# If the credentials are not specified, random self-generated ones will be used and written to {{ credentials_file_path }}
 credentials:
   manager:
     admin_username: 'admin'

--- a/cfy_cluster_manager/cfy_cluster_config_files/cfy_three_nodes_cluster_config.yaml
+++ b/cfy_cluster_manager/cfy_cluster_config_files/cfy_three_nodes_cluster_config.yaml
@@ -1,8 +1,8 @@
-# Your private key local path to connect to all hosts
-key_file_path: ''
+# Your private SSH key local path used to connect to all VMs
+ssh_key_path: ''
 
-# The hosts' username, e.g. centos
-machine_username: ''
+# The VMs' SSH username, e.g. centos
+ssh_user: ''
 
 # Local path to a valid Cloudify license
 cloudify_license_path: ''
@@ -10,11 +10,13 @@ cloudify_license_path: ''
 # Manager RPM to install on the cluster instances
 manager_rpm_download_link: 'http://cloudify-release-eu.s3.amazonaws.com/cloudify/5.1.0/.dev1-release/cloudify-manager-install-5.1.0-.dev1.el7.x86_64.rpm'
 
-# If specified, all the VMs certificates will need to be specified as well
+# If specified, all the VMs' certificates will need to be specified as well
 ca_cert_path: ''
 
 # If using a load-balancer, please provide its IP.
-# This IP will be written the the config.yaml files.
+# This IP will be written to the manager config.yaml files under
+# networks[load_balancer].
+# Remark: The load balancer is not installed during the cluster installation.
 load_balancer_ip: ''
 
 
@@ -41,7 +43,7 @@ existing_vms:
       key_path: ''  # Need to be supplied if ca_cert_path was supplied
 
 
-# If the credentials are not specified, random ones will be used and written to {{ credentials_file_path }}
+# If the credentials are not specified, random self-generated ones will be used and written to {{ credentials_file_path }}
 credentials:
   manager:
     admin_username: 'admin'

--- a/cfy_cluster_manager/cfy_cluster_config_files/cfy_three_nodes_external_db_cluster_config.yaml
+++ b/cfy_cluster_manager/cfy_cluster_config_files/cfy_three_nodes_external_db_cluster_config.yaml
@@ -1,8 +1,8 @@
-# Your private key local path to connect to all hosts
-key_file_path: ''
+# Your private SSH key local path used to connect to all VMs
+ssh_key_path: ''
 
-# The hosts' username, e.g. centos
-machine_username: ''
+# The VMs' SSH username, e.g. centos
+ssh_user: ''
 
 # Local path to a valid Cloudify license
 cloudify_license_path: ''
@@ -10,11 +10,13 @@ cloudify_license_path: ''
 # Manager RPM to install on the cluster instances
 manager_rpm_download_link: 'http://cloudify-release-eu.s3.amazonaws.com/cloudify/5.1.0/.dev1-release/cloudify-manager-install-5.1.0-.dev1.el7.x86_64.rpm'
 
-# If specified, all the VMs certificates will need to be specified as well
+# If specified, all the VMs' certificates will need to be specified as well
 ca_cert_path: ''
 
 # If using a load-balancer, please provide its IP.
-# This IP will be written the the config.yaml files.
+# This IP will be written to the manager config.yaml files under
+# networks[load_balancer].
+# Remark: The load balancer is not installed during the cluster installation.
 load_balancer_ip: ''
 
 
@@ -65,7 +67,7 @@ external_db_configuration:
   cloudify_password: ''
 
 
-# If the credentials are not specified, random ones will be used and written to {{ credentials_file_path }}
+# If the credentials are not specified, random self-generated ones will be used and written to {{ credentials_file_path }}
 credentials:
   manager:
     admin_username: 'admin'

--- a/cfy_cluster_manager/main.py
+++ b/cfy_cluster_manager/main.py
@@ -599,7 +599,9 @@ def generate_config(output_path,
     if exists(output_path):
         override_file = input('The path {} already exists, would you like '
                               'to override it? (yes/no) '.format(output_path))
-        if override_file.lower() == 'no':
+        if override_file.lower() not in ('yes', 'y', 'no', 'n'):
+            raise ClusterInstallError('Please respond with a yes or no')
+        if override_file.lower() in ('no', 'n'):
             logger.info('Please provide a different path to the configuration '
                         'file using the `--output` flag. Exiting..')
             exit(1)

--- a/cfy_cluster_manager/main.py
+++ b/cfy_cluster_manager/main.py
@@ -380,18 +380,16 @@ def _get_external_db_config(config):
 
 
 def _get_cfy_node(config, node_dict, node_name, validate_connection=True):
-    username = config.get('machine_username')
     cert_path = join(CERTS_DIR, node_name + '_cert.pem')
     key_path = join(CERTS_DIR, node_name + '_key.pem')
     if _using_provided_certificates(config):
         copy(expanduser(node_dict.get('cert_path')), cert_path)
         copy(expanduser(node_dict.get('key_path')), key_path)
 
-    public_ip = node_dict.get('public_ip') or node_dict.get('private_ip')
     new_vm = CfyNode(node_dict.get('private_ip'),
-                     public_ip,
-                     config.get('key_file_path'),
-                     username,
+                     node_dict.get('public_ip'),
+                     config.get('ssh_key_path'),
+                     config.get('ssh_user'),
                      node_name,
                      node_dict.get('hostname'),
                      cert_path,
@@ -565,8 +563,8 @@ def _validate_external_db_config(config, errors_list):
 
 def _validate_config(config):
     errors_list = []
-    _check_path(config, 'key_file_path', errors_list)
-    _check_value_provided(config, 'machine_username', errors_list)
+    _check_path(config, 'ssh_key_path', errors_list)
+    _check_value_provided(config, 'ssh_user', errors_list)
     _check_path(config, 'cloudify_license_path', errors_list)
     _check_value_provided(config, 'manager_rpm_download_link', errors_list)
     _validate_existing_vms(config, errors_list)
@@ -582,35 +580,48 @@ def _handle_cluster_config_file(cluster_config_file_name, output_path):
     template = cluster_config_files_env.get_template(cluster_config_file_name)
     rendered_data = template.render(
         credentials_file_path=CREDENTIALS_FILE_PATH)
-    cluster_config_file_path = join(
-        CLUSTER_CONFIG_FILES_DIR, cluster_config_file_name)
-    with open(cluster_config_file_path, 'w') as cluster_config_file:
-        cluster_config_file.write(rendered_data)
-    copy(cluster_config_file_path, output_path)
+    with open(output_path, 'w') as output_file:
+        output_file.write(rendered_data)
 
 
 def generate_config(output_path,
                     verbose,
                     using_three_nodes,
+                    using_nine_nodes,
                     using_external_db):
     setup_logger(verbose)
     output_path = output_path or CLUSTER_INSTALL_CONFIG_PATH
+
+    if (not using_nine_nodes) and (not using_three_nodes):
+        raise ClusterInstallError(
+            'Please specify `--three-nodes` or `--nine-nodes`.')
+
+    if exists(output_path):
+        override_file = input('The path {} already exists, would you like '
+                              'to override it? (yes/no) '.format(output_path))
+        if override_file.lower() == 'no':
+            logger.info('Please provide a different path to the configuration '
+                        'file using the `--output` flag. Exiting..')
+            exit(1)
+
     if isdir(output_path):
         output_path = join(output_path, CLUSTER_CONFIG_FILE_NAME)
 
-    if using_three_nodes:
+    if using_nine_nodes:
+        if using_external_db:
+            _handle_cluster_config_file(
+                'cfy_nine_nodes_external_db_cluster_config.yaml', output_path)
+        else:
+            _handle_cluster_config_file(
+                'cfy_nine_nodes_cluster_config.yaml', output_path)
+
+    elif using_three_nodes:
         if using_external_db:
             _handle_cluster_config_file(
                 'cfy_three_nodes_external_db_cluster_config.yaml', output_path)
         else:
             _handle_cluster_config_file(
                 'cfy_three_nodes_cluster_config.yaml', output_path)
-
-    elif using_external_db:
-        _handle_cluster_config_file(
-            'cfy_external_db_cluster_config.yaml', output_path)
-    else:
-        _handle_cluster_config_file(CLUSTER_CONFIG_FILE_NAME, output_path)
 
     logger.info('Created the cluster install configuration file in %s',
                 output_path)
@@ -763,11 +774,20 @@ def main():
         help='The local path to save the cluster install configuration file '
              'to. default: ./{0}'.format(CLUSTER_CONFIG_FILE_NAME))
 
-    generate_config_args.add_argument(
+    exclusive_options = generate_config_args.add_mutually_exclusive_group()
+
+    exclusive_options.add_argument(
         '--three-nodes',
         action='store_true',
         default=False,
-        help='Using a three nodes cluster.')
+        help='Using a three nodes cluster')
+
+    exclusive_options.add_argument(
+        '--nine-nodes',
+        action='store_true',
+        default=False,
+        help='Using a nine nodes cluster. In case of using an external DB, '
+             'Only 6 nodes will need to be provided')
 
     generate_config_args.add_argument(
         '--external-db',
@@ -802,7 +822,7 @@ def main():
 
     if args.action == 'generate-config':
         generate_config(args.output, args.verbose, args.three_nodes,
-                        args.external_db)
+                        args.nine_nodes, args.external_db)
 
     elif args.action == 'install':
         install(args.config_path, args.override, args.verbose)

--- a/cfy_cluster_manager/utils.py
+++ b/cfy_cluster_manager/utils.py
@@ -88,7 +88,7 @@ class VM(object):
                  username):
         self.username = username
         self.private_ip = private_ip
-        self.public_ip = public_ip
+        self.public_ip = public_ip or private_ip
         self.key_file_path = expanduser(key_file_path)
 
     def _get_connection(self):


### PR DESCRIPTION
We would like to a `--nine-nodes` flag to the `cfy_cluster_manager generate-config` function. This way, the user would have to choose between a three-nodes cluster configuration and a nine-nodes.
This PR also changes some of the syntaxes in the configuration files.