### PR TITLE
Adding install unit tests

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest
 pytest-cov
 pyyaml>=5.3.0,<5.4.0
+mock>=4.0.0,<4.1.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,13 @@ def config_dir(tmp_path):
 
 
 @pytest.fixture(autouse=True)
+def cluster_manager_dir(tmp_path):
+    cluster_manager_dir = tmp_path / 'cloudify_cluster_manager'
+    cluster_manager_dir.mkdir()
+    return cluster_manager_dir
+
+
+@pytest.fixture(autouse=True)
 def ssh_key_path(config_dir):
     ssh_key_path = config_dir / 'key_file.pem'
     ssh_key_path.write_text(u'test_key_path')
@@ -26,19 +33,40 @@ def license_path(config_dir):
 
 
 @pytest.fixture(autouse=True)
-def ca_path(config_dir):
-    ca_path = config_dir / 'ca.pem'
-    ca_path.write_text(u'test_ca_path')
-    return str(ca_path)
-
-
-@pytest.fixture(autouse=True)
 def basic_config_dict(ssh_key_path, license_path):
     return {
         'ssh_key_path': ssh_key_path,
         'ssh_user': 'centos',
         'cloudify_license_path': license_path
     }
+
+
+@pytest.fixture()
+def tmp_certs_dir(tmp_path):
+    tmp_certs_dir = tmp_path / 'tmp_certs'
+    tmp_certs_dir.mkdir()
+    return tmp_certs_dir
+
+
+@pytest.fixture()
+def ca_path(tmp_certs_dir):
+    ca_path = tmp_certs_dir / 'ca.pem'
+    ca_path.write_text(u'test_ca_path')
+    return str(ca_path)
+
+
+@pytest.fixture()
+def ldap_ca_path(tmp_certs_dir):
+    ldap_ca_path = tmp_certs_dir / 'ldap_ca.pem'
+    ldap_ca_path.write_text(u'test_ldap_ca_path')
+    return str(ldap_ca_path)
+
+
+@pytest.fixture()
+def external_db_ca_path(tmp_certs_dir):
+    external_db_ca_path = tmp_certs_dir / 'external_db_ca.pem'
+    external_db_ca_path.write_text(u'test_external_db_ca_path')
+    return str(external_db_ca_path)
 
 
 @pytest.fixture()

--- a/tests/resources/three_nodes_config.yaml
+++ b/tests/resources/three_nodes_config.yaml
@@ -25,6 +25,7 @@ existing_vms:
       key_path: ''
       config_path:
         manager_config_path: ''
+        postgresql_config_path: ''
         rabbitmq_config_path: ''
 
     node-2:
@@ -35,6 +36,7 @@ existing_vms:
       key_path: ''
       config_path:
         manager_config_path: ''
+        postgresql_config_path: ''
         rabbitmq_config_path: ''
 
     node-3:
@@ -45,6 +47,7 @@ existing_vms:
       key_path: ''
       config_path:
         manager_config_path: ''
+        postgresql_config_path: ''
         rabbitmq_config_path: ''
 
 credentials:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -141,7 +141,7 @@ def test_ldap_in_config_file(three_nodes_config_dict,
     # In this case, The three nodes and nine nodes logic is the same
     cluster_manager_ldap_ca = str(cluster_manager_certs_dir / 'ldap_ca.pem')
     ldap_dict = {
-        'server': 'ldaps://1.1.1.1',
+        'server': 'ldaps://192.0.2.12',
         'domain': 'test_domain',
         'is_active_directory': True,
         'ca_cert': ldap_ca_path,
@@ -175,7 +175,7 @@ def test_extrnal_db_in_config_file(three_nodes_external_db_config_dict,
     cluster_manager_external_db_ca = str(
         cluster_manager_certs_dir / 'external_db_ca.pem')
     external_db_config = {
-        'host': 'user.postgres.database.azure.com',
+        'host': 'user.postgres.database.azure.example',
         'ca_path': external_db_ca_path,
         'server_db_name': 'postgres',
         'server_username': 'user@user',

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,308 @@
+import copy
+import mock
+import filecmp
+
+import yaml
+import pytest
+
+import cfy_cluster_manager
+from cfy_cluster_manager.main import (_generate_general_cluster_dict,
+                                      _generate_three_nodes_cluster_dict,
+                                      _handle_certificates,
+                                      _populate_credentials,
+                                      _prepare_config_files)
+
+
+@pytest.fixture(autouse=True)
+def mock_test_connection():
+    cfy_cluster_manager.main.CfyNode.test_connection = mock.Mock(
+        return_value=None)
+
+
+@pytest.fixture(autouse=True)
+def mock_generate_certs():
+    cfy_cluster_manager.main._generate_certs = mock.Mock(return_value=None)
+
+
+@pytest.fixture()
+def cluster_manager_certs_dir(cluster_manager_dir):
+    return cluster_manager_dir / cfy_cluster_manager.main.CERTS_DIR_NAME
+
+
+@pytest.fixture()
+def config_files_dir(cluster_manager_dir):
+    return cluster_manager_dir / cfy_cluster_manager.main.CONFIG_FILES
+
+
+def test_three_nodes_using_provided_certificates(three_nodes_config_dict,
+                                                 cluster_manager_certs_dir,
+                                                 tmp_certs_dir,
+                                                 ca_path):
+    """Testing if the install code uses the provided certificates.
+
+    In case certificates were provided for all existing_vms, the install code
+    would copy the certificates to the CERTS_DIR with their appropriate name.
+    This test verifies this behavior for the three nodes cluster use case.
+    """
+    three_nodes_config_dict['ca_cert_path'] = ca_path
+    for node_name, node_dict in three_nodes_config_dict[
+            'existing_vms'].items():
+        node_num = node_name.split('-')[1]
+        for service in 'postgresql', 'rabbitmq', 'manager':
+            cert_path = (tmp_certs_dir /
+                         '{0}-{1}_{2}.pem'.format(service, node_num, 'cert'))
+            key_path = (tmp_certs_dir /
+                        '{0}-{1}_{2}.pem'.format(service, node_num, 'key'))
+            cert_path.write_text(u'manager-{0}_{1}'.format(node_num, 'cert'))
+            key_path.write_text(u'manager-{0}_{1}'.format(node_num, 'key'))
+
+        node_dict['cert_path'] = str(cert_path)
+        node_dict['key_path'] = str(key_path)
+
+    with mock.patch('cfy_cluster_manager.main.CERTS_DIR',
+                    str(cluster_manager_certs_dir)):
+        _generate_three_nodes_cluster_dict(three_nodes_config_dict)
+
+    with mock.patch('cfy_cluster_manager.main.CA_PATH',
+                    str(cluster_manager_certs_dir / 'ca.pem')):
+        _handle_certificates(three_nodes_config_dict, None)
+
+    _assert_created_certs(tmp_certs_dir, cluster_manager_certs_dir)
+
+
+def test_nine_nodes_using_provided_certificates(nine_nodes_config_dict,
+                                                cluster_manager_certs_dir,
+                                                tmp_certs_dir,
+                                                ca_path):
+    """Testing if the install code uses the provided certificates.
+
+    In case certificates were provided for all existing_vms, the install code
+    would copy the certificates to the CERTS_DIR with their appropriate name.
+    This test verifies this behavior for the nine nodes cluster use case.
+    """
+    nine_nodes_config_dict['ca_cert_path'] = ca_path
+    for node_name, node_dict in nine_nodes_config_dict['existing_vms'].items():
+        for val in 'key', 'cert':
+            val_path = tmp_certs_dir / '{0}_{1}.pem'.format(node_name, val)
+            val_path.write_text(u'{0}_{1}'.format(node_name, val))
+            node_dict['{0}_path'.format(val)] = str(val_path)
+
+    with mock.patch('cfy_cluster_manager.main.CERTS_DIR',
+                    str(cluster_manager_certs_dir)):
+        _generate_general_cluster_dict(nine_nodes_config_dict)
+
+    with mock.patch('cfy_cluster_manager.main.CA_PATH',
+                    str(cluster_manager_certs_dir / 'ca.pem')):
+        _handle_certificates(nine_nodes_config_dict, None)
+
+    _assert_created_certs(tmp_certs_dir, cluster_manager_certs_dir)
+
+
+def test_credentials_randomly_generated(three_nodes_config_dict):
+    """Test if the credentials are randomly generated and populated.
+
+    In order to test this, we first set the value of arbitrary keys to a
+    fixed value. Then, we test if these keys kept their value and if all other
+    values were populated.
+    """
+    # In this case, The three nodes and nine nodes logic is the same
+    fixed_value = 'fixed_value'
+    chosen_keys = [
+        ('rabbitmq', 'username'),
+        ('postgresql', 'cluster', 'etcd', 'cluster_token'),
+        ('postgresql', 'db_monitoring', 'username'),
+        ('prometheus', 'password')
+    ]
+    credentials_dict = three_nodes_config_dict.get('credentials')
+    _iterate_nested_dict(credentials_dict, chosen_keys, fixed_value)
+    _populate_credentials(credentials_dict)
+    _assert_dict_values_not_none(credentials_dict)
+    _iterate_nested_dict(credentials_dict, chosen_keys, fixed_value, True)
+
+
+def test_config_files_credentials(three_nodes_config_dict, config_files_dir):
+    """Test the credentials in the config files are populated correctly."""
+    # In this case, The three nodes and nine nodes logic is the same
+    credentials_dict = three_nodes_config_dict.get('credentials')
+    _populate_credentials(credentials_dict)
+    _create_config_files(three_nodes_config_dict, config_files_dir,
+                         credentials_dict)
+    _assert_manager_config_credentials(config_files_dir, credentials_dict)
+    _assert_postgresql_config_credentials(config_files_dir, credentials_dict)
+    _assert_rabbitmq_config_credentials(config_files_dir, credentials_dict)
+
+
+def test_ldap_in_config_file(three_nodes_config_dict,
+                             config_files_dir,
+                             ldap_ca_path,
+                             tmp_certs_dir,
+                             cluster_manager_certs_dir):
+    """Test if LDAP is configured properly in the manager config.yaml file."""
+    # In this case, The three nodes and nine nodes logic is the same
+    cluster_manager_ldap_ca = str(cluster_manager_certs_dir / 'ldap_ca.pem')
+    ldap_dict = {
+        'server': 'ldaps://1.1.1.1',
+        'domain': 'test_domain',
+        'is_active_directory': True,
+        'ca_cert': ldap_ca_path,
+        'username': 'test_username',
+        'password': 'test_password',
+        'dn_extra': 'test_dn_extra'
+    }
+    three_nodes_config_dict.update({'ldap': copy.deepcopy(ldap_dict)})
+
+    with mock.patch('cfy_cluster_manager.main.LDAP_CA_PATH',
+                    cluster_manager_ldap_ca):
+        _handle_certificates(three_nodes_config_dict, None)
+        _create_config_files(three_nodes_config_dict, config_files_dir)
+    manager_config = _get_instance_config('manager', config_files_dir)
+
+    ldap_dict['ca_cert'] = cluster_manager_ldap_ca
+    assert manager_config['restservice']['ldap'] == ldap_dict
+    _assert_created_certs(tmp_certs_dir, cluster_manager_certs_dir)
+
+
+def test_extrnal_db_in_config_file(three_nodes_external_db_config_dict,
+                                   config_files_dir,
+                                   external_db_ca_path,
+                                   tmp_certs_dir,
+                                   cluster_manager_certs_dir):
+    """
+    Test if the external_db is configured properly in the manager
+    config.yaml file.
+    """
+    # In this case, The three nodes and nine nodes logic is the same
+    cluster_manager_external_db_ca = str(
+        cluster_manager_certs_dir / 'external_db_ca.pem')
+    external_db_config = {
+        'host': 'user.postgres.database.azure.com',
+        'ca_path': external_db_ca_path,
+        'server_db_name': 'postgres',
+        'server_username': 'user@user',
+        'server_password': 'strongpassword',
+        'cloudify_db_name': 'cloudify_db',
+        'cloudify_username': 'cloudify@user',
+        'cloudify_password': 'cloudify'
+    }
+    three_nodes_external_db_config_dict.update(
+        {'external_db_configuration': copy.deepcopy(external_db_config)})
+
+    with mock.patch('cfy_cluster_manager.main.EXTERNAL_DB_CA_PATH',
+                    cluster_manager_external_db_ca):
+        _handle_certificates(three_nodes_external_db_config_dict, None)
+        _create_config_files(three_nodes_external_db_config_dict,
+                             config_files_dir)
+    manager_config = _get_instance_config('manager', config_files_dir)
+
+    external_db_config.update({'ssl_client_verification': False,
+                               'ca_path': cluster_manager_external_db_ca})
+    assert manager_config['postgresql_client'] == external_db_config
+    _assert_created_certs(tmp_certs_dir, cluster_manager_certs_dir)
+
+
+def _assert_manager_config_credentials(config_files_dir, credentials):
+    manager_config = _get_instance_config('manager', config_files_dir)
+
+    assert (manager_config['manager']['security']['admin_username'] ==
+            credentials['manager']['admin_username'])
+
+    assert (manager_config['manager']['security']['admin_password'] ==
+            credentials['manager']['admin_password'])
+
+    assert (manager_config['postgresql_server']['postgres_password'] ==
+            credentials['postgresql']['postgres_password'])
+
+    assert (manager_config['rabbitmq']['username'] ==
+            credentials['rabbitmq']['username'])
+
+    assert (manager_config['rabbitmq']['password'] ==
+            credentials['rabbitmq']['password'])
+
+    assert (manager_config['prometheus']['credentials']['username'] ==
+            credentials['prometheus']['username'])
+
+    assert (manager_config['prometheus']['credentials']['password'] ==
+            credentials['prometheus']['password'])
+
+
+def _assert_postgresql_config_credentials(config_files_dir, credentials):
+    postgresql_config = _get_instance_config('postgresql', config_files_dir)
+
+    assert (postgresql_config['postgresql_server']['postgres_password'] ==
+            credentials['postgresql']['postgres_password'])
+
+    assert (credentials['postgresql']['cluster'].items() <=
+            postgresql_config['postgresql_server']['cluster'].items())
+
+    assert (credentials['postgresql']['db_monitoring'].items() <=
+            postgresql_config['postgresql_server']['db_monitoring'].items())
+
+    assert (postgresql_config['prometheus']['credentials']['username'] ==
+            credentials['prometheus']['username'])
+
+    assert (postgresql_config['prometheus']['credentials']['password'] ==
+            credentials['prometheus']['password'])
+
+
+def _assert_rabbitmq_config_credentials(config_files_dir, credentials):
+    rabbitmq_config = _get_instance_config('rabbitmq', config_files_dir)
+
+    assert (rabbitmq_config['rabbitmq']['username'] ==
+            credentials['rabbitmq']['username'])
+
+    assert (rabbitmq_config['rabbitmq']['password'] ==
+            credentials['rabbitmq']['password'])
+
+    assert (rabbitmq_config['prometheus']['credentials']['username'] ==
+            credentials['prometheus']['username'])
+
+    assert (rabbitmq_config['prometheus']['credentials']['password'] ==
+            credentials['prometheus']['password'])
+
+
+def _get_instance_config(instance, config_files_dir):
+    with open(
+            str(config_files_dir / '{}-1_config.yaml'.format(instance)), 'r') \
+            as instance_config:
+        return yaml.load(instance_config, yaml.Loader)
+
+
+def _create_config_files(config_dict, config_files_dir, credentials=None):
+    if not credentials:
+        credentials = config_dict.get('credentials')
+        _populate_credentials(credentials)
+    instnaces_dict = _generate_three_nodes_cluster_dict(config_dict)
+    with mock.patch('cfy_cluster_manager.main.CONFIG_FILES_DIR',
+                    str(config_files_dir)):
+        _prepare_config_files(instnaces_dict, credentials, config_dict)
+
+
+def _iterate_nested_dict(original_dict,
+                         keys_tuples_list,
+                         fixed_value,
+                         test=False):
+    tmp_dict = original_dict
+    for keys_tuple in keys_tuples_list:
+        for i, key in enumerate(keys_tuple):
+            if i + 1 < len(keys_tuple):
+                tmp_dict = tmp_dict[key]
+            else:
+                if test:
+                    assert tmp_dict[key] == fixed_value
+                else:
+                    tmp_dict[key] = fixed_value
+        tmp_dict = original_dict
+
+
+def _assert_dict_values_not_none(tested_dict):
+    for key, value in tested_dict.items():
+        if isinstance(value, dict):
+            _assert_dict_values_not_none(value)
+        else:
+            assert value is not None
+
+
+def _assert_created_certs(tmp_certs_dir, cluster_manager_certs_dir):
+    for original_path in tmp_certs_dir.iterdir():
+        tested_path = cluster_manager_certs_dir / original_path.name
+        assert filecmp.cmp(str(original_path), str(tested_path))

--- a/tests/test_validations.py
+++ b/tests/test_validations.py
@@ -94,12 +94,12 @@ def test_validate_external_db_paths(three_nodes_external_db_config_dict):
 
 
 def test_validate_success_external_db(three_nodes_external_db_config_dict,
-                                      ca_path):
+                                      external_db_ca_path):
     # It's enough to test it only on the three nodes external db config,
     # since the nine nodes external db config uses the same logic.
     three_nodes_external_db_config_dict['external_db_configuration'] = {
         'host': 'user.postgres.database.azure.com',
-        'ca_path': ca_path,
+        'ca_path': external_db_ca_path,
         'server_db_name': 'postgres',
         'server_username': 'user@user',
         'server_password': 'strongpassword',


### PR DESCRIPTION
This PR adds unit tests that test the install process' functions. The installation process involves a few steps: 
1. Validating the provided cluster configuration file. This is already tested in `test_validations.py`.
2. Checking for a previous installation. 
3. Preparing the `cloudify_cluster_manager` directory that includes all the necessary files for installation. This directory will be passed to all instances and includes the instances' certificates, config files, and Cloudify license.
4. Generating certificates in case they are not provided. And if they are provided, copying them to their correct location in the `cloudify_cluster_manager` directory. 
5. Handling the different credentials that will be written to the different config.yaml files. In case they are not provided in the cluster configuration file, they will be generated by a random string generator function.
6. Preparing the instances' config.yaml files. 
7. The final step, installing the instances. 

Since these are only unit tests, they don't test the installation itself, but the preparation of the `cloudify_cluster_manager` directory. I.e. each test tests a different step in the creation of this directory to make sure all files are created as expected.
To match the description above, the steps that are being tested are: 
4 - Testing that the provided certificates are passed correctly to their location in the `cloudify_cluster_manager` directory. 
5 - Testing that all needed credentials are filled, and that those that were supplied are not changed. Moreover, testing that the config.yaml files are populated with the right credentials. 
6 - The config.yaml files are populated correctly in case an LDAP or external DB section was provided.

Please let me know what you think, and if more tests should be added.