### PR TITLE
Fixing provided certificates usage

### DIFF
--- a/cfy_cluster_manager/utils.py
+++ b/cfy_cluster_manager/utils.py
@@ -77,8 +77,7 @@ def copy(source, destination):
 
 def move(source, destination):
     ensure_destination_dir_exists(destination)
-    sudo(['cp', source, destination])
-    sudo(['rm', source])
+    sudo(['mv', source, destination])
 
 
 class VM(object):

--- a/cfy_cluster_manager/utils.py
+++ b/cfy_cluster_manager/utils.py
@@ -77,7 +77,8 @@ def copy(source, destination):
 
 def move(source, destination):
     ensure_destination_dir_exists(destination)
-    sudo(['mv', source, destination])
+    sudo(['cp', source, destination])
+    sudo(['rm', source])
 
 
 class VM(object):


### PR DESCRIPTION
This PR fixes a bug in the handling of provided certificates. The bug was that when certificates were provided, the code created the `cloudify-cluster-manager` directory, puts the certificates in it, and then overrides it.