### PR TITLE
Ignoring credentials when using config files duplicate

### DIFF
--- a/cfy_cluster_manager/cfy_cluster_config_files/cfy_nine_nodes_cluster_config.yaml
+++ b/cfy_cluster_manager/cfy_cluster_config_files/cfy_nine_nodes_cluster_config.yaml
@@ -135,10 +135,6 @@ credentials:
       postgres:
         replicator_password: ''
 
-    db_monitoring:
-      username: ''
-      password: ''
-
   rabbitmq:
     username: ''
     password: ''

--- a/cfy_cluster_manager/cfy_cluster_config_files/cfy_three_nodes_cluster_config.yaml
+++ b/cfy_cluster_manager/cfy_cluster_config_files/cfy_three_nodes_cluster_config.yaml
@@ -100,10 +100,6 @@ credentials:
       postgres:
         replicator_password: ''
 
-    db_monitoring:
-      username: ''
-      password: ''
-
   rabbitmq:
     username: ''
     password: ''

--- a/cfy_cluster_manager/config_files_templates/postgresql_config.yaml
+++ b/cfy_cluster_manager/config_files_templates/postgresql_config.yaml
@@ -26,8 +26,6 @@ postgresql_server:
     postgres:
       replicator_password: {{ creds.postgresql.cluster.postgres.replicator_password }}
 
-  db_monitoring: {{ creds.postgresql.db_monitoring }}
-
 
 prometheus:
   credentials:

--- a/cfy_cluster_manager/main.py
+++ b/cfy_cluster_manager/main.py
@@ -740,9 +740,6 @@ def _using_provided_config_files(instances_dict):
 
 
 def _handle_certificates(config, instances_dict):
-    if _using_provided_config_files(instances_dict):
-        return
-
     if _using_provided_certificates(config):
         copy(expanduser(config.get('ca_cert_path')), CA_PATH)
         for instances_list in instances_dict.values():
@@ -920,8 +917,9 @@ def install(config_path, override, only_validate, verbose):
         copy(config.get('cloudify_license_path'),
              join(CLUSTER_INSTALL_DIR, 'license.yaml'))
         _install_cloudify_locally(rpm_download_link)
-        _handle_certificates(config, instances_dict)
-        credentials = _handle_credentials(config.get('credentials'))
+        if not _using_provided_config_files(instances_dict):
+            _handle_certificates(config, instances_dict)
+            credentials = _handle_credentials(config.get('credentials'))
         _prepare_config_files(instances_dict, credentials, config)
 
     _install_instances(instances_dict, using_three_nodes_cluster,

--- a/cfy_cluster_manager/main.py
+++ b/cfy_cluster_manager/main.py
@@ -968,7 +968,7 @@ def add_config_arg(parser):
     parser.add_argument(
         '--config-path',
         action='store',
-        help='The completed cluster configuration file. default: '
+        help='The completed cluster configuration file. Default: '
              './{0}'.format(CLUSTER_CONFIG_FILE_NAME)
     )
 
@@ -988,7 +988,7 @@ def main():
         '-o', '--output',
         action='store',
         help='The local path to save the cluster install configuration file '
-             'to. default: ./{0}'.format(CLUSTER_CONFIG_FILE_NAME))
+             'to. Default: ./{0}'.format(CLUSTER_CONFIG_FILE_NAME))
 
     exclusive_options = generate_config_args.add_mutually_exclusive_group()
 

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -43,7 +43,7 @@ def buildClusterManagerRPM(String version, String prerelease, String branchName=
 pipeline {
   agent {
     kubernetes {
-      label 'cloudify-cluster-manager'
+      label 'cloudify-cluster-manager-label'
       defaultContainer 'jnlp'
       yamlFile 'jenkins/build-pod.yaml'
     }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -43,7 +43,7 @@ def buildClusterManagerRPM(String version, String prerelease, String branchName=
 pipeline {
   agent {
     kubernetes {
-      label 'cluster-manager'
+      label 'cloudify-cluster-manager'
       defaultContainer 'jnlp'
       yamlFile 'jenkins/build-pod.yaml'
     }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -43,7 +43,7 @@ def buildClusterManagerRPM(String version, String prerelease, String branchName=
 pipeline {
   agent {
     kubernetes {
-      label 'cloudify-cluster-manager-label'
+      label 'cluster-manager-${env.BUILD_NUMBER}'
       defaultContainer 'jnlp'
       yamlFile 'jenkins/build-pod.yaml'
     }

--- a/jenkins/Jenkinsfile
+++ b/jenkins/Jenkinsfile
@@ -43,7 +43,7 @@ def buildClusterManagerRPM(String version, String prerelease, String branchName=
 pipeline {
   agent {
     kubernetes {
-      label 'cloudify-cluster-manager'
+      label 'cluster-manager'
       defaultContainer 'jnlp'
       yamlFile 'jenkins/build-pod.yaml'
     }

--- a/jenkins/build-pod.yaml
+++ b/jenkins/build-pod.yaml
@@ -38,4 +38,4 @@ spec:
     - cat
     tty: true
   nodeSelector:
-    instance-type: spot
+    instance-type: spot-xlarge

--- a/jenkins/build-pod.yaml
+++ b/jenkins/build-pod.yaml
@@ -38,4 +38,4 @@ spec:
     - cat
     tty: true
   nodeSelector:
-    instance-type: spot-xlarge
+    instance-type: spot

--- a/tests/resources/nine_nodes_config.yaml
+++ b/tests/resources/nine_nodes_config.yaml
@@ -106,9 +106,6 @@ credentials:
       postgres:
         replicator_password: ''
 
-    db_monitoring:
-      username: ''
-      password: ''
 
   rabbitmq:
     username: ''

--- a/tests/resources/three_nodes_config.yaml
+++ b/tests/resources/three_nodes_config.yaml
@@ -67,9 +67,6 @@ credentials:
       postgres:
         replicator_password: ''
 
-    db_monitoring:
-      username: ''
-      password: ''
 
   rabbitmq:
     username: ''

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -112,7 +112,6 @@ def test_credentials_randomly_generated(three_nodes_config_dict):
     chosen_keys = [
         ('rabbitmq', 'username'),
         ('postgresql', 'cluster', 'etcd', 'cluster_token'),
-        ('postgresql', 'db_monitoring', 'username'),
         ('prometheus', 'password')
     ]
     credentials_dict = three_nodes_config_dict.get('credentials')
@@ -268,9 +267,6 @@ def _assert_postgresql_config_credentials(config_files_dir, credentials):
 
     assert (credentials['postgresql']['cluster'].items() <=
             postgresql_config['postgresql_server']['cluster'].items())
-
-    assert (credentials['postgresql']['db_monitoring'].items() <=
-            postgresql_config['postgresql_server']['db_monitoring'].items())
 
     assert (postgresql_config['prometheus']['credentials']['username'] ==
             credentials['prometheus']['username'])


### PR DESCRIPTION
This PR handles a number of issues:
1. Ignoring the input credentials when the user provides its own config files.
2. Removing db_monitoring from the config files. I ran into some weird errors during the system tests where the DB was in a failed state at the end of the installation, and @mateumann had it might be related to the db_monitoring configuration. 
3. Changing the label in the Jenkins file to be configured differently on each build and changing the spot configuration to xlarge.