### PR TITLE
RD-867 Create cfy_cluster_manager upgrade command

### DIFF
--- a/cfy_cluster_manager/main.py
+++ b/cfy_cluster_manager/main.py
@@ -509,6 +509,8 @@ def _print_success_message(start_time, msg='installed'):
     m, s = divmod(running_time, 60)
     logger.info('Cloudify cluster was successfully {0} in '
                 '{1} minutes and {2} seconds'.format(msg, int(m), int(s)))
+    logger.info('Please run `cfy cluster status` to verify the cluster status '
+                'is healthy. It might take up to a minute for it to stabilize')
 
 
 def _install_cloudify_locally(rpm_path):


### PR DESCRIPTION
Upgrade from v5.1.0 to v5.1.1 can be done by a new command - `cfy_manager upgrade`. This PR adds this functionality to the `cfy_cluster_manager` tool.

**REMINDER:** Replace the 5.1.1 default RPM path with the ga path when it's released.