### PR TITLE
RD-2583 Fix installation with ssl_enabled: false

### DIFF
--- a/cfy_cluster_manager/cfy_cluster_config_files/cfy_nine_nodes_cluster_config.yaml
+++ b/cfy_cluster_manager/cfy_cluster_config_files/cfy_nine_nodes_cluster_config.yaml
@@ -42,6 +42,7 @@ ldap:
 
 # If specified, all the VMs' certificates will need to be specified as well
 ca_cert_path: ''
+ca_key_path: ''
 
 # If using a load-balancer, please provide its IP.
 # This IP will be written to the manager config.yaml files under

--- a/cfy_cluster_manager/cfy_cluster_config_files/cfy_nine_nodes_external_db_cluster_config.yaml
+++ b/cfy_cluster_manager/cfy_cluster_config_files/cfy_nine_nodes_external_db_cluster_config.yaml
@@ -42,6 +42,7 @@ ldap:
 
 # If specified, all the VMs certificates will need to be specified as well
 ca_cert_path: ''
+ca_key_path: ''
 
 # If using a load-balancer, please provide its IP.
 # This IP will be written to the manager config.yaml files under

--- a/cfy_cluster_manager/cfy_cluster_config_files/cfy_three_nodes_cluster_config.yaml
+++ b/cfy_cluster_manager/cfy_cluster_config_files/cfy_three_nodes_cluster_config.yaml
@@ -42,6 +42,7 @@ ldap:
 
 # If specified, all the VMs' certificates will need to be specified as well
 ca_cert_path: ''
+ca_key_path: ''
 
 # If using a load-balancer, please provide its IP.
 # This IP will be written to the manager config.yaml files under

--- a/cfy_cluster_manager/cfy_cluster_config_files/cfy_three_nodes_external_db_cluster_config.yaml
+++ b/cfy_cluster_manager/cfy_cluster_config_files/cfy_three_nodes_external_db_cluster_config.yaml
@@ -42,6 +42,7 @@ ldap:
 
 # If specified, all the VMs' certificates will need to be specified as well
 ca_cert_path: ''
+ca_key_path: ''
 
 # If using a load-balancer, please provide its IP.
 # This IP will be written to the manager config.yaml files under

--- a/cfy_cluster_manager/config_files_templates/manager_config.yaml
+++ b/cfy_cluster_manager/config_files_templates/manager_config.yaml
@@ -60,12 +60,14 @@ ssl_inputs:
   external_cert_path: {{ node.cert_path }}
   external_key_path: {{ node.key_path }}
   external_ca_cert_path: {{ ca_path }}
+  external_ca_key_path: {{ ca_key_path }}
   {%-endif %}
   internal_cert_path: {{ node.cert_path }}
   internal_key_path: {{ node.key_path }}
   postgresql_client_cert_path: {{ node.cert_path }}
   postgresql_client_key_path: {{ node.key_path }}
   ca_cert_path: {{ ca_path }}
+  ca_key_path: {{ ca_key_path }}
 
 prometheus:
   credentials:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,13 @@ def ca_path(tmp_certs_dir):
 
 
 @pytest.fixture()
+def ca_key_path(tmp_certs_dir):
+    ca_key_path = tmp_certs_dir / 'ca.key'
+    ca_key_path.write_text(u'test_ca_key_path')
+    return str(ca_key_path)
+
+
+@pytest.fixture()
 def ldap_ca_path(tmp_certs_dir):
     ldap_ca_path = tmp_certs_dir / 'ldap_ca.pem'
     ldap_ca_path.write_text(u'test_ldap_ca_path')

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -42,7 +42,8 @@ def config_files_dir(cluster_manager_dir):
 def test_three_nodes_using_provided_certificates(three_nodes_config_dict,
                                                  certs_dir,
                                                  tmp_certs_dir,
-                                                 ca_path):
+                                                 ca_path,
+                                                 ca_key_path):
     """Testing if the install code uses the provided certificates.
 
     In case certificates were provided for all existing_vms, the install code
@@ -50,6 +51,7 @@ def test_three_nodes_using_provided_certificates(three_nodes_config_dict,
     This test verifies this behavior for the three nodes cluster use case.
     """
     three_nodes_config_dict['ca_cert_path'] = ca_path
+    three_nodes_config_dict['ca_key_path'] = ca_key_path
     for node_name, node_dict in three_nodes_config_dict[
             'existing_vms'].items():
         node_num = node_name.split('-')[1]
@@ -66,7 +68,9 @@ def test_three_nodes_using_provided_certificates(three_nodes_config_dict,
 
     with mock.patch('cfy_cluster_manager.main.CA_PATH',
                     str(certs_dir / 'ca.pem')), \
-            mock.patch('cfy_cluster_manager.main.CERTS_DIR', str(certs_dir)):
+            mock.patch('cfy_cluster_manager.main.CERTS_DIR', str(certs_dir)), \
+            mock.patch('cfy_cluster_manager.main.CA_KEY_PATH',
+                       str(certs_dir / 'ca.key')):
         cluster_dict = _generate_three_nodes_cluster_dict(
             three_nodes_config_dict)
         _handle_certificates(three_nodes_config_dict, cluster_dict)
@@ -77,7 +81,8 @@ def test_three_nodes_using_provided_certificates(three_nodes_config_dict,
 def test_nine_nodes_using_provided_certificates(nine_nodes_config_dict,
                                                 certs_dir,
                                                 tmp_certs_dir,
-                                                ca_path):
+                                                ca_path,
+                                                ca_key_path):
     """Testing if the install code uses the provided certificates.
 
     In case certificates were provided for all existing_vms, the install code
@@ -85,6 +90,7 @@ def test_nine_nodes_using_provided_certificates(nine_nodes_config_dict,
     This test verifies this behavior for the nine nodes cluster use case.
     """
     nine_nodes_config_dict['ca_cert_path'] = ca_path
+    nine_nodes_config_dict['ca_key_path'] = ca_key_path
     for node_name, node_dict in nine_nodes_config_dict['existing_vms'].items():
         for val in 'key', 'cert':
             val_path = tmp_certs_dir / '{0}_{1}.pem'.format(node_name, val)
@@ -93,7 +99,9 @@ def test_nine_nodes_using_provided_certificates(nine_nodes_config_dict,
 
     with mock.patch('cfy_cluster_manager.main.CA_PATH',
                     str(certs_dir / 'ca.pem')), \
-            mock.patch('cfy_cluster_manager.main.CERTS_DIR', str(certs_dir)):
+            mock.patch('cfy_cluster_manager.main.CERTS_DIR', str(certs_dir)), \
+            mock.patch('cfy_cluster_manager.main.CA_KEY_PATH',
+                       str(certs_dir / 'ca.key')):
         cluster_dict = _generate_general_cluster_dict(nine_nodes_config_dict)
         _handle_certificates(nine_nodes_config_dict, cluster_dict)
 


### PR DESCRIPTION
Currently, installing a cluster with `ssl_enabled: false` fails because the manager installation requires the CA key. 
This PR fixes this by providing it.