### PR TITLE
Don't use a TTY with systemd-run

### DIFF
--- a/cfy_cluster_manager/main.py
+++ b/cfy_cluster_manager/main.py
@@ -390,7 +390,7 @@ def _install_instances(instances_dict, verbose):
                 instance.config_path), use_sudo=True)
 
             install_cmd = (
-                'systemd-run -t --unit {unit_name} --uid {user_name} '
+                'systemd-run --unit {unit_name} --uid {user_name} '
                 'cfy_manager install -c {config} {verbose}'.format(
                     config=instance.config_path, unit_name=instance.unit_name,
                     user_name=getuser(), verbose='-v' if verbose else ''))


### PR DESCRIPTION
It'll fail if the system calling it doesn't have one (e.g.
when running systemtests via a heredoc or on jenkins).