### PR TITLE
Don't copy raw config over correct one

### DIFF
--- a/cfy_cluster_manager/main.py
+++ b/cfy_cluster_manager/main.py
@@ -399,9 +399,6 @@ def _install_instances(instances_dict, verbose):
 
             instance.run_command(install_cmd, use_sudo=True)
             _verify_cloudify_installed_successfully(instance)
-            instance.run_command('cp {0} {1}'.format(
-                '/etc/cloudify/config.yaml', instance.config_path),
-                use_sudo=True)
 
 
 def _sort_instances_dict(instances_dict):


### PR DESCRIPTION
This is a legacy of when we didn't copy the config out of temp
but did overwrite the main config.yaml with the last used config.