### PR TITLE
RD-4895 Use yaml.safe_load instead of yaml.load

### DIFF
--- a/cfy_cluster_manager/main.py
+++ b/cfy_cluster_manager/main.py
@@ -241,7 +241,7 @@ def _create_config_file(node, rendered_data=None):
     config_path = join(CONFIG_FILES_DIR, '{0}_config.yaml'.format(node.name))
     if rendered_data:
         if node.extra_config:
-            config = yaml.load(rendered_data)
+            config = yaml.safe_load(rendered_data)
             _update_config(config, node.extra_config)
             rendered_data = yaml.dump(config)
         with open(config_path, 'w') as config_file:

--- a/cfy_cluster_manager/scripts/create_installation_files.py
+++ b/cfy_cluster_manager/scripts/create_installation_files.py
@@ -139,7 +139,7 @@ def read_yaml_file(yaml_path):
         try:
             file_content = sudo_read(yaml_path)
             yaml = YAML(typ='safe', pure=True)
-            return yaml.load(file_content)
+            return yaml.safe_load(file_content)
         except YAMLError as e:
             raise YAMLError('Failed to load yaml file {0}, due to {1}'
                             ''.format(yaml_path, str(e)))

--- a/cfy_cluster_manager/utils.py
+++ b/cfy_cluster_manager/utils.py
@@ -197,7 +197,7 @@ class VM(object):
 
 def get_dict_from_yaml(yaml_path):
     with open(yaml_path) as yaml_file:
-        yaml_dict = yaml.load(yaml_file, yaml.Loader)
+        yaml_dict = yaml.safe_load(yaml_file)
     return yaml_dict
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,7 +103,7 @@ def _get_config_dict(config_file_name, basic_config_dict):
     resources_path = join(dirname(__file__), 'resources')
     completed_config_path = join(resources_path, config_file_name)
     with open(completed_config_path) as config_path:
-        config_dict = yaml.load(config_path, yaml.Loader)
+        config_dict = yaml.safe_load(config_path)
 
     config_dict.update(basic_config_dict)
     return config_dict

--- a/tests/test_generate_config.py
+++ b/tests/test_generate_config.py
@@ -44,9 +44,9 @@ def test_fail_three_and_nine_nodes_not_supplied():
 def _assert_same_config_contents(output_path, config_name):
     """Assert the output file is the same as the configuration file."""
     with open(join(CONFIG_FILES_PATH, config_name)) as config_file:
-        config_dict = yaml.load(config_file, yaml.Loader)
+        config_dict = yaml.safe_load(config_file)
     with open(output_path) as output_file:
-        output_dict = yaml.load(output_file, yaml.Loader)
+        output_dict = yaml.safe_load(output_file)
     err_msg = ('The output file {0} is not the same as the config file '
                '{1}'.format(output_path, config_name))
     assert config_dict == output_dict, err_msg

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -318,7 +318,7 @@ def _get_instance_config(instance, config_files_dir):
     with open(
             str(config_files_dir / '{}-1_config.yaml'.format(instance)), 'r') \
             as instance_config:
-        return yaml.load(instance_config, yaml.Loader)
+        return yaml.safe_load(instance_config)
 
 
 def _create_config_files(config_dict, config_files_dir, credentials=None,


### PR DESCRIPTION
There were some places it was called without the loader, which broke
when those code paths were reached.

As we don't actually need the extra power of unsafe yaml, we might as
well just use the safe one.